### PR TITLE
Fix: squid:S1148: Throwable.printStackTrace(...) should not be called…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapper.java
@@ -21,19 +21,19 @@ public class NvmWrapper extends BuildWrapper {
 
   private final static Logger log = Logger.getLogger(NvmWrapperUtil.class.getName());
 
-  public String getVersion() {
-    return version;
-  }
-
-  public void setVersion(String version) {
-    this.version = version;
-  }
-
   private String version;
   private transient NvmWrapperUtil wrapperUtil;
 
   @DataBoundConstructor
   public NvmWrapper(String version) {
+    this.version = version;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
     this.version = version;
   }
 

--- a/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapperUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapperUtil.java
@@ -5,6 +5,7 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.util.ArgumentListBuilder;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +17,8 @@ import java.util.stream.Collectors;
  * Created by atoms on 6/9/16.
  */
 public class NvmWrapperUtil {
+
+  private static final Logger LOGGER = Logger.getLogger(NvmWrapperUtil.class.getName());
 
   private AbstractBuild build;
   private Launcher launcher;
@@ -109,9 +112,9 @@ public class NvmWrapperUtil {
           .stdout(listener.getLogger())
           .stderr(listener.getLogger()).join();
       } catch (IOException e) {
-        e.printStackTrace();
+        LOGGER.info(e.getMessage(), e);
       } catch (InterruptedException e) {
-        e.printStackTrace();
+        LOGGER.info(e.getMessage(), e);
       }
       return statusCode == 0;
     }).findFirst().orElse(null);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
  squid:S1148 - “Throwable.printStackTrace(...) should not be called”. 
  squid:S00122- “Statements should be on separate lines”. 
 You can find more information about the issues here: 
   https://dev.eclipse.org/sonar/rules/show/squid:S1148
   https://dev.eclipse.org/sonar/rules/show/squid:S00122
 Please let me know if you have any questions.
Ayman Elkfrawy"